### PR TITLE
respect Node-RED httpRoot setting

### DIFF
--- a/sonospollytts/sonospollytts.js
+++ b/sonospollytts/sonospollytts.js
@@ -461,7 +461,7 @@ module.exports = function(RED) {
         iVoice = voices[config.voice].Id;
 
         // Store Noder-Red complete URL
-        sNoderedURL="http://"+ config.noderedipaddress + ":" + config.noderedport;
+        sNoderedURL="http://"+ config.noderedipaddress + ":" + config.noderedport + RED.settings.httpRoot;
 
         // Create sonos client
         SonosClient = new sonos.Sonos(sSonosIPAddress);


### PR DESCRIPTION
fixes https://github.com/HM-RedMatic/RedMatic/issues/160 - this is necessary e.g. in environments where Node-RED runs behind a reverse proxy on a non-root path.